### PR TITLE
Fix CLI timeline command and split AST definitions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,9 +18,5 @@ bambusa = "bambusa.cli.main:main"
 [tool.setuptools.packages.find]
 where = ["src"]
 
-[build-system]
-requires = ["setuptools>=61"]
-build-backend = "setuptools.build_meta"
-
 [tool.pytest.ini_options]
 pythonpath = ["src"]

--- a/src/bambusa/__main__.py
+++ b/src/bambusa/__main__.py
@@ -4,33 +4,11 @@
 
 from __future__ import annotations
 
-import argparse
-import sys
-
-from .parser import cli as parser_cli
-from bambusa.cli.main import main
-
-def _build_parser() -> argparse.ArgumentParser:
-    parser = argparse.ArgumentParser(prog="bambusa", description="Bambusa language utilities")
-    subparsers = parser.add_subparsers(dest="command", required=True)
-
-    parse_parser = subparsers.add_parser("parse", help="Parse a Bambusa source file")
-    parser_cli.configure_parse_subcommand(parse_parser)
-
-    return parser
+from bambusa.cli.main import main as cli_main
 
 
 def main(argv: list[str] | None = None) -> int:
-    parser = _build_parser()
-    args = parser.parse_args(argv)
-
-    if args.command == "parse":
-        return parser_cli.handle_parse_command(args)
-
-    parser.error(f"Unknown command: {args.command}")
-    return 2
-
-
+    return cli_main(argv)
 
 
 if __name__ == "__main__":

--- a/src/bambusa/ast.py
+++ b/src/bambusa/ast.py
@@ -1,86 +1,81 @@
-"""Abstract syntax tree nodes for the Bambusa surface language prototype."""
-
+"""Lightweight AST nodes used by the lowering pipeline."""
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import List, Sequence
+from typing import Sequence, Tuple
 
 
+# ---------------------------------------------------------------------------
+# Expressions
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
 class Expression:
-    """Base class for expressions."""
+    """Base class for expression nodes."""
 
 
-class Statement:
-    """Base class for statements."""
-
-
-@dataclass(slots=True)
-class Program:
-    """A complete Bambusa program consisting of top-level functions."""
-
-    functions: Sequence["Function"]
-
-
-@dataclass(slots=True)
-class Function:
-    """A function declaration with a name, parameters, and body."""
-
-    name: str
-    params: Sequence[str]
-    body: Sequence[Statement]
-
-
-@dataclass(slots=True)
+@dataclass(frozen=True)
 class Literal(Expression):
     value: object
 
 
-@dataclass(slots=True)
+@dataclass(frozen=True)
 class Var(Expression):
     name: str
 
 
-@dataclass(slots=True)
+@dataclass(frozen=True)
 class BinaryOp(Expression):
     left: Expression
     op: str
     right: Expression
 
 
-@dataclass(slots=True)
+@dataclass(frozen=True)
 class Compare(Expression):
     left: Expression
     op: str
     right: Expression
 
 
-@dataclass(slots=True)
+@dataclass(frozen=True)
 class Load(Expression):
     array: str
     index: Expression
 
 
-@dataclass(slots=True)
+# ---------------------------------------------------------------------------
+# Statements
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class Statement:
+    """Base class for statement nodes."""
+
+
+@dataclass(frozen=True)
 class Assign(Statement):
     target: str
     value: Expression
 
 
-@dataclass(slots=True)
+@dataclass(frozen=True)
 class Store(Statement):
     array: str
     index: Expression
     value: Expression
 
 
-@dataclass(slots=True)
+@dataclass(frozen=True)
 class IfElse(Statement):
     condition: Expression
-    then_body: Sequence[Statement] = field(default_factory=list)
-    else_body: Sequence[Statement] = field(default_factory=list)
+    then_body: Sequence[Statement]
+    else_body: Sequence[Statement] = field(default_factory=tuple)
 
 
-@dataclass(slots=True)
+@dataclass(frozen=True)
 class ForLoop(Statement):
     target: str
     start: Expression
@@ -88,9 +83,26 @@ class ForLoop(Statement):
     body: Sequence[Statement]
 
 
-@dataclass(slots=True)
+@dataclass(frozen=True)
 class Return(Statement):
     value: Expression
+
+
+# ---------------------------------------------------------------------------
+# Program container
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class Function:
+    name: str
+    params: Sequence[str]
+    body: Sequence[Statement]
+
+
+@dataclass(frozen=True)
+class Program:
+    functions: Sequence[Function]
 
 
 __all__ = [

--- a/src/bambusa/cli/main.py
+++ b/src/bambusa/cli/main.py
@@ -7,11 +7,19 @@ import json
 from typing import List, Optional
 
 from bambusa.debug.timeline import Timeline
+from bambusa.parser import cli as parser_cli
 
 
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(prog="bambusa", description="Bambusa developer tools")
     subparsers = parser.add_subparsers(dest="command", required=True)
+
+    parse_parser = subparsers.add_parser(
+        "parse",
+        help="Parse a Bambusa source file",
+        description="Inspect the parse tree produced from Bambusa source code",
+    )
+    parser_cli.configure_parse_subcommand(parse_parser)
 
     timeline_parser = subparsers.add_parser(
         "timeline",
@@ -33,6 +41,8 @@ def main(argv: Optional[List[str]] = None) -> int:
 
     if args.command == "timeline":
         return run_timeline(args)
+    if args.command == "parse":
+        return parser_cli.handle_parse_command(args)
     parser.error(f"Unsupported command: {args.command}")
     return 2
 

--- a/src/bambusa/parser/ast_builder.py
+++ b/src/bambusa/parser/ast_builder.py
@@ -7,7 +7,7 @@ from antlr4 import CommonTokenStream, InputStream, ParserRuleContext, Token
 from antlr4.error.ErrorListener import ErrorListener
 from antlr4.tree.Tree import TerminalNode
 
-from ..ast import (
+from ..semantic.ast_nodes import (
     ArrayType,
     Assignment,
     BinaryOp,

--- a/src/bambusa/runtime/executor.py
+++ b/src/bambusa/runtime/executor.py
@@ -1,28 +1,22 @@
-"""Branchless IR execution harness built on the persistent heap."""
-"""Runtime executor for Bambusa IR with structured logging.
-
-This module provides a small, test-focused executor for Bambusa's toy
-intermediate representation.  The executor understands a handful of
-high-level operations that are sufficient for the unit tests and emits a
-structured log containing a snapshot of the runtime state after every step.
-"""
-
-from __future__ import annotations
-
-from typing import Any, Dict, Iterable, MutableMapping, Sequence
-
-from .persistent_heap import PersistentHeap, PersistentVector, compact, masked_load, masked_store
-
-
+"""Runtime executors for Bambusa IR."""
 from __future__ import annotations
 
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Dict, Iterable, List, Mapping, MutableMapping, Optional
-import json
+from typing import Any, Dict, Iterable, List, Mapping, MutableMapping, Optional, Sequence
 import copy
+import json
 
-class Executor:
+from .persistent_heap import (
+    PersistentHeap,
+    PersistentVector,
+    compact,
+    masked_load,
+    masked_store,
+)
+
+
+class BranchlessExecutor:
     """A tiny interpreter for the branchless Bambusa IR.
 
     The interpreter operates on a dictionary based IR where every instruction is
@@ -155,31 +149,7 @@ class Executor:
 
 @dataclass
 class IRStep:
-    """Represents a single Bambusa IR step.
-
-    Parameters
-    ----------
-    op:
-        The opcode to execute.  Supported opcodes are ``assign``, ``add``,
-        ``mul``, ``mask_select`` and ``emit``.
-    args:
-        Arguments for the opcode.  The expected shape depends on the opcode:
-
-        ``assign``
-            ``{"target": str, "value": Any}``
-        ``add``
-            ``{"target": str, "value": Any}`` – the value is added to the
-            current value of the target variable (defaulting to ``0``).
-        ``mul``
-            ``{"target": str, "value": Any}`` – multiplies the current value
-            by the provided value.
-        ``mask_select``
-            ``{"target": str, "mask": bool, "on_true": Any, "on_false": Any}``
-            – stores ``on_true`` when the mask is truthy, otherwise ``on_false``.
-        ``emit``
-            ``{"channel": str, "value": Any}`` – appends the value to the
-            ``emissions`` buffer under the given channel.
-    """
+    """Represents a single Bambusa IR step."""
 
     op: str
     args: Mapping[str, Any]
@@ -197,20 +167,7 @@ class StructuredLogWriter:
             self._file = self._path.open("w", encoding="utf-8")
 
     def snapshot(self, *, step: int, instruction: Mapping[str, Any], state: Mapping[str, Any]) -> None:
-        """Write a snapshot entry.
-
-        Parameters
-        ----------
-        step:
-            The zero-based step index.
-        instruction:
-            A JSON-serialisable representation of the IR step that just
-            executed.
-        state:
-            A mapping describing the current runtime state.  The mapping is
-            copied before serialisation to ensure immutability of historical
-            entries.
-        """
+        """Write a snapshot entry."""
 
         if self._file is None:
             return
@@ -231,7 +188,7 @@ class StructuredLogWriter:
     def __enter__(self) -> "StructuredLogWriter":
         return self
 
-    def __exit__(self, exc_type, exc, tb) -> None:
+    def __exit__(self, exc_type, exc, tb) -> None:  # noqa: D401 - delegated cleanup
         self.close()
 
 
@@ -259,20 +216,7 @@ class Executor:
         return IRStep(op=op, args=args)
 
     def run(self, *, log_path: Path | str | None = None) -> List[Dict[str, Any]]:
-        """Execute all steps and optionally persist a structured log.
-
-        Parameters
-        ----------
-        log_path:
-            Optional path to a log file that will receive JSON-line snapshots
-            after each executed step.
-
-        Returns
-        -------
-        list of dict
-            The full list of snapshot entries generated during execution.  The
-            same payload is written to ``log_path`` when provided.
-        """
+        """Execute all steps and optionally persist a structured log."""
 
         snapshots: List[Dict[str, Any]] = []
         with StructuredLogWriter(log_path) as writer:
@@ -337,5 +281,4 @@ class Executor:
         return args[key]
 
 
-__all__ = ["Executor", "IRStep", "StructuredLogWriter"]
-
+__all__ = ["BranchlessExecutor", "Executor", "IRStep", "StructuredLogWriter"]

--- a/src/bambusa/semantic/__init__.py
+++ b/src/bambusa/semantic/__init__.py
@@ -1,0 +1,7 @@
+"""Semantic analysis utilities for Bambusa."""
+
+from . import ast_nodes
+from .ast_nodes import *  # noqa: F401,F403 - re-export for convenience
+from .type_checker import SemanticError, type_check
+
+__all__ = list(ast_nodes.__all__) + ["SemanticError", "type_check"]

--- a/src/bambusa/semantic/ast_nodes.py
+++ b/src/bambusa/semantic/ast_nodes.py
@@ -1,0 +1,216 @@
+"""Typed abstract syntax tree definitions for the Bambusa language."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import List, Optional
+
+
+@dataclass(frozen=True)
+class SourceLocation:
+    """Represents a point in the original source program."""
+
+    line: int
+    column: int
+
+
+@dataclass(frozen=True)
+class Type:
+    """Base class for Bambusa types."""
+
+    def is_numeric(self) -> bool:
+        return False
+
+    def is_bool(self) -> bool:
+        return False
+
+    def __str__(self) -> str:  # pragma: no cover - presentation helper
+        return self.__class__.__name__
+
+
+@dataclass(frozen=True)
+class PrimitiveType(Type):
+    """Represents primitive scalar types."""
+
+    name: str
+
+    def is_numeric(self) -> bool:
+        return self.name in {"int", "float"}
+
+    def is_bool(self) -> bool:
+        return self.name == "bool"
+
+    def __str__(self) -> str:  # pragma: no cover - presentation helper
+        return self.name
+
+
+@dataclass(frozen=True)
+class ArrayType(Type):
+    """An array type with a homogeneous element type."""
+
+    element_type: Type
+
+    def __str__(self) -> str:  # pragma: no cover - presentation helper
+        return f"{self.element_type}[]"
+
+
+INT_TYPE = PrimitiveType("int")
+FLOAT_TYPE = PrimitiveType("float")
+BOOL_TYPE = PrimitiveType("bool")
+VOID_TYPE = PrimitiveType("void")
+
+
+@dataclass
+class Node:
+    """Base class for all AST nodes."""
+
+    location: SourceLocation
+
+
+@dataclass
+class Statement(Node):
+    """Base class for statements."""
+
+
+@dataclass
+class Expression(Node):
+    """Base class for expressions."""
+
+    inferred_type: Optional[Type] = field(init=False, default=None)
+
+
+@dataclass
+class Literal(Expression):
+    value: object
+
+
+@dataclass
+class Identifier(Expression):
+    name: str
+
+
+@dataclass
+class UnaryOp(Expression):
+    operator: str
+    operand: Expression
+
+
+@dataclass
+class BinaryOp(Expression):
+    left: Expression
+    operator: str
+    right: Expression
+
+
+@dataclass
+class ConditionalExpr(Expression):
+    condition: Expression
+    then_expr: Expression
+    else_expr: Expression
+
+
+@dataclass
+class Block(Statement):
+    statements: List[Statement]
+
+
+@dataclass
+class ExprStmt(Statement):
+    value: Expression
+
+
+@dataclass
+class VarDecl(Statement):
+    type: Type
+    name: str
+    initializer: Optional[Expression] = None
+
+
+@dataclass
+class Assignment(Statement):
+    name: str
+    value: Expression
+
+    @property
+    def target(self) -> str:
+        return self.name
+
+
+@dataclass
+class IfStmt(Statement):
+    condition: Expression
+    then_block: Block
+    else_block: Optional[Block] = None
+
+
+@dataclass
+class Range(Node):
+    start: Expression
+    end: Expression
+
+
+@dataclass
+class ForStmt(Statement):
+    iterator: str
+    range: Range
+    body: Block
+
+
+@dataclass
+class ReturnStmt(Statement):
+    value: Expression
+
+
+@dataclass
+class Parameter(Node):
+    type: Type
+    name: str
+
+
+@dataclass
+class FunctionDecl(Node):
+    name: str
+    params: List[Parameter]
+    return_type: Type
+    body: Block
+
+
+@dataclass
+class GlobalDecl(Node):
+    type: Type
+    name: str
+    value: Expression
+
+
+@dataclass
+class Program(Node):
+    globals: List[GlobalDecl]
+    functions: List[FunctionDecl]
+
+
+__all__ = [
+    "ArrayType",
+    "Assignment",
+    "BinaryOp",
+    "Block",
+    "BOOL_TYPE",
+    "ConditionalExpr",
+    "ExprStmt",
+    "FLOAT_TYPE",
+    "ForStmt",
+    "FunctionDecl",
+    "GlobalDecl",
+    "INT_TYPE",
+    "Identifier",
+    "IfStmt",
+    "Literal",
+    "Parameter",
+    "Program",
+    "Range",
+    "ReturnStmt",
+    "SourceLocation",
+    "Statement",
+    "Type",
+    "UnaryOp",
+    "VarDecl",
+    "VOID_TYPE",
+]

--- a/src/bambusa/semantic/type_checker.py
+++ b/src/bambusa/semantic/type_checker.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Dict, List, Optional
 
-from .. import ast
+from . import ast_nodes as ast
 
 
 @dataclass


### PR DESCRIPTION
## Summary
- remove the duplicate build-system table from the project configuration
- restructure the runtime executor and CLI so both parse and timeline tools work via `python -m bambusa`
- split the surface-level AST used by lowering from the typed AST used by semantic analysis and update imports accordingly

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68d9cc021f608328b0cf57f47f08943d