### PR TITLE
Support reading timeline logs from stdin

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,13 @@ Inspect the execution afterwards using the CLI:
 $ bambusa timeline run.log
 ```
 
+The CLI also accepts ``-`` to read the log from standard input, which makes it
+easy to pipe data directly from other tools:
+
+```bash
+$ cat run.log | bambusa timeline - --json
+```
+
 Interactive commands:
 
 ```

--- a/src/bambusa/cli/main.py
+++ b/src/bambusa/cli/main.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import sys
 from typing import List, Optional
 
 from bambusa.debug.timeline import Timeline
@@ -48,7 +49,10 @@ def main(argv: Optional[List[str]] = None) -> int:
 
 
 def run_timeline(args: argparse.Namespace) -> int:
-    timeline = Timeline.from_log(args.log)
+    if args.log == "-":
+        timeline = Timeline.from_stream(sys.stdin)
+    else:
+        timeline = Timeline.from_log(args.log)
     root = timeline.fork()
 
     if args.json:

--- a/src/bambusa/debug/timeline.py
+++ b/src/bambusa/debug/timeline.py
@@ -39,16 +39,20 @@ class Timeline:
 
     @classmethod
     def from_log(cls, path: str | Path) -> "Timeline":
-        entries = []
         with Path(path).open("r", encoding="utf-8") as handle:
-            for line in handle:
-                line = line.strip()
-                if not line:
-                    continue
-                payload = json.loads(line)
-                entries.append(TimelineEntry.from_payload(payload))
+            return cls.from_stream(handle)
+
+    @classmethod
+    def from_stream(cls, stream: Iterable[str]) -> "Timeline":
+        entries: List[TimelineEntry] = []
+        for line in stream:
+            line = line.strip()
+            if not line:
+                continue
+            payload = json.loads(line)
+            entries.append(TimelineEntry.from_payload(payload))
         if not entries:
-            raise ValueError("Log file is empty")
+            raise ValueError("Log stream produced no entries")
         return cls(entries)
 
     # ------------------------------------------------------------------

--- a/tests/debug/test_timeline.py
+++ b/tests/debug/test_timeline.py
@@ -1,6 +1,7 @@
 import json
 import os
 import subprocess
+from io import StringIO
 from pathlib import Path
 
 import pytest
@@ -74,3 +75,32 @@ def test_cli_json_mode(sample_log: Path) -> None:
     payload = json.loads(result.stdout.decode("utf-8"))
     assert len(payload) == 4
     assert payload[0]["state"]["x"] == 1
+
+
+def test_timeline_from_stream(sample_log: Path) -> None:
+    log_text = sample_log.read_text(encoding="utf-8")
+    timeline = Timeline.from_stream(StringIO(log_text))
+
+    assert timeline.size == 4
+    assert timeline.current_step == 0
+    timeline.seek(3)
+    assert timeline.current_state["emissions"]["stdout"] == ["done"]
+
+
+def test_cli_json_mode_stdin(sample_log: Path) -> None:
+    env = os.environ.copy()
+    src_path = str(Path.cwd() / "src")
+    env["PYTHONPATH"] = f"{src_path}:{env.get('PYTHONPATH', '')}".rstrip(":")
+
+    log_text = sample_log.read_text(encoding="utf-8")
+    result = subprocess.run(
+        ["python", "-m", "bambusa", "timeline", "-", "--json"],
+        input=log_text,
+        text=True,
+        check=True,
+        capture_output=True,
+        env=env,
+    )
+    payload = json.loads(result.stdout)
+    assert len(payload) == 4
+    assert payload[-1]["step"] == 3


### PR DESCRIPTION
## Summary
- allow the `bambusa timeline` command to read execution logs from stdin
- share log parsing between file and stream sources
- extend timeline tests and README documentation for the new workflow

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68da64baff808328865bea8533c559a5