### PR TITLE
Fix Timeline.diff default comparison step

### DIFF
--- a/src/bambusa/debug/timeline.py
+++ b/src/bambusa/debug/timeline.py
@@ -129,7 +129,7 @@ class Timeline:
         """
 
         left_state = self._state_at(step)
-        comparison_step = other_step if other_step is not None else (step if step is not None else other.current_step)
+        comparison_step = other.current_step if other_step is None else other_step
         right_state = other._state_at(comparison_step)
         return _diff_states(left_state, right_state)
 

--- a/tests/debug/test_timeline.py
+++ b/tests/debug/test_timeline.py
@@ -60,6 +60,20 @@ def test_timeline_fork_and_diff(sample_log: Path) -> None:
     assert delta["changed"]["emissions"]["left"] == fork_state["emissions"]
 
 
+def test_timeline_diff_defaults_to_other_current_step(sample_log: Path) -> None:
+    root = Timeline.from_log(sample_log)
+    fork = root.fork()
+
+    fork.seek(2)
+    root.seek(0)
+
+    diff = fork.diff(root, step=2)
+
+    assert diff["removed"].get("y") == 3
+    assert diff["changed"]["x"]["left"] == 3
+    assert diff["changed"]["x"]["right"] == 1
+
+
 def test_cli_json_mode(sample_log: Path) -> None:
     log = sample_log
     env = os.environ.copy()


### PR DESCRIPTION
## Summary
- ensure `Timeline.diff` defaults to comparing against the other timeline's current step when no comparison step is provided
- expand timeline debugger tests to cover default comparison step behaviour

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68da64bec0b88328ab81ae8a814c2963