### PR TITLE
Add package marker for generated parser modules

### DIFF
--- a/src/bambusa/parser/generated/__init__.py
+++ b/src/bambusa/parser/generated/__init__.py
@@ -1,0 +1,1 @@
+"""Package marker for generated parser modules."""


### PR DESCRIPTION
## Summary
- add an __init__.py module to the generated parser package so it is included in wheels

## Testing
- python -m build

------
https://chatgpt.com/codex/tasks/task_e_68da7cc873e883288eadaf89db158bdb