### PR TITLE
Update ANTLR runtime dependency

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,0 +1,7 @@
+# Release Notes
+
+## Unreleased
+
+- Updated the ANTLR runtime dependency to `antlr4-python3-runtime==4.13.2` to
+  pull in the latest fixes from the upstream project.
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ description = "Utilities for parsing the Bambusa language"
 readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [
-  "antlr4-python3-runtime==4.13.1",
+  "antlr4-python3-runtime==4.13.2",
 ]
 
 [project.scripts]


### PR DESCRIPTION
## Summary
- bump antlr4-python3-runtime to 4.13.2 in pyproject
- document the dependency update in the release notes

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68da7cc70d088328876b8dec7575e3cf