### PR TITLE
Fix executor mul default and add regression test

### DIFF
--- a/src/bambusa/runtime/executor.py
+++ b/src/bambusa/runtime/executor.py
@@ -259,7 +259,7 @@ class Executor:
     def _handle_mul(self, args: Mapping[str, Any]) -> None:
         target = self._require(args, "target")
         value = args.get("value", 1)
-        self.state[target] = self.state.get(target, 0) * value
+        self.state[target] = self.state.get(target, 1) * value
 
     def _handle_mask_select(self, args: Mapping[str, Any]) -> None:
         target = self._require(args, "target")

--- a/tests/runtime/test_executor.py
+++ b/tests/runtime/test_executor.py
@@ -1,0 +1,15 @@
+from bambusa.runtime.executor import Executor
+
+
+def test_mul_initialises_missing_register_to_operand() -> None:
+    executor = Executor([
+        {
+            "op": "mul",
+            "target": "result",
+            "value": 7,
+        }
+    ])
+
+    executor.run()
+
+    assert executor.state["result"] == 7


### PR DESCRIPTION
## Summary
- ensure the executor's mul handler multiplies against 1 when the target register is unset
- add a regression test covering a single mul step to verify the behaviour

## Testing
- pytest tests/runtime/test_executor.py

------
https://chatgpt.com/codex/tasks/task_e_68da7cc3a3c88328bffd8fc9d0c5ba25