### PR TITLE
Add runtime comparison opcodes and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,10 +128,30 @@ Structural sharing can optimize copies, but immutability is the default.
 ## 🚧 Status
 
 Bambusa is in its **conceptual and prototyping stage**:
-- ✅ Core branchless IR defined  
-- ✅ ANTLR grammar written  
-- ✅ Toy Python simulator implemented  
+- ✅ Core branchless IR defined
+- ✅ ANTLR grammar written
+- ✅ Toy Python simulator implemented
 - ⏳ Next: LLVM IR backend, timeline debugger, persistent heap runtime
+
+## 🧪 Runtime opcodes
+
+The Python runtime executes a lightweight dictionary-based IR.  Opcodes mirror
+the structures emitted by the lowering pipeline so that tests, tooling, and the
+eventual compiler backend agree on semantics.  Arithmetic instructions retain
+their verb-style names (``add``, ``sub``, ``mul``), while comparisons use the
+``cmp_<mnemonic>`` form that corresponds to the Bambusa surface syntax:
+
+| Surface operator | Opcode   |
+| ---------------- | -------- |
+| ``==``           | ``cmp_eq`` |
+| ``!=``           | ``cmp_ne`` |
+| ``<``            | ``cmp_lt`` |
+| ``<=``           | ``cmp_le`` |
+| ``>``            | ``cmp_gt`` |
+| ``>=``           | ``cmp_ge`` |
+
+The resulting boolean can be wired directly into other branchless primitives
+such as ``select`` or mask-producing operations.
 
 ## 🧭 Timeline Debugger
 

--- a/src/bambusa/runtime/executor.py
+++ b/src/bambusa/runtime/executor.py
@@ -1,11 +1,26 @@
-"""Runtime executors for Bambusa IR."""
+"""Runtime executors for Bambusa IR.
+
+The branchless executor operates on dictionary based instructions.  Opcodes
+follow a simple naming scheme so they can be emitted mechanically from the
+lowering pipeline:
+
+* Arithmetic operations use short English verbs (``add``, ``sub``, ``mul``)
+  that mirror :class:`bambusa.ir.Binary` nodes.
+* Comparisons use the ``cmp_<mnemonic>`` form where ``<mnemonic>`` is the
+  familiar LLVM-style suffix derived from the Bambusa surface syntax
+  (``==`` → ``eq``, ``!=`` → ``ne``, ``<`` → ``lt``, ``<=`` → ``le``, ``>`` →
+  ``gt``, ``>=`` → ``ge``).  This keeps the opcode names stable relative to
+  :class:`bambusa.ir.Compare` operations while staying friendly to downstream
+  interpreters.
+"""
 from __future__ import annotations
 
+import copy
+import json
+import operator
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Dict, Iterable, List, Mapping, MutableMapping, Optional, Sequence
-import copy
-import json
 
 from .persistent_heap import (
     PersistentHeap,
@@ -84,6 +99,35 @@ class BranchlessExecutor:
         lhs = self._resolve(instruction.get("lhs"))
         rhs = self._resolve(instruction.get("rhs"))
         return lhs * rhs
+
+    # Comparisons -----------------------------------------------------
+    def _compare(self, instruction: MutableMapping[str, Any], op) -> bool:
+        try:
+            lhs_operand = instruction["lhs"]
+            rhs_operand = instruction["rhs"]
+        except KeyError as exc:  # pragma: no cover - sanity guard
+            raise ValueError("comparison operations require 'lhs' and 'rhs'") from exc
+        lhs = self._resolve(lhs_operand)
+        rhs = self._resolve(rhs_operand)
+        return op(lhs, rhs)
+
+    def _op_cmp_eq(self, instruction: MutableMapping[str, Any]) -> bool:
+        return self._compare(instruction, operator.eq)
+
+    def _op_cmp_ne(self, instruction: MutableMapping[str, Any]) -> bool:
+        return self._compare(instruction, operator.ne)
+
+    def _op_cmp_lt(self, instruction: MutableMapping[str, Any]) -> bool:
+        return self._compare(instruction, operator.lt)
+
+    def _op_cmp_le(self, instruction: MutableMapping[str, Any]) -> bool:
+        return self._compare(instruction, operator.le)
+
+    def _op_cmp_gt(self, instruction: MutableMapping[str, Any]) -> bool:
+        return self._compare(instruction, operator.gt)
+
+    def _op_cmp_ge(self, instruction: MutableMapping[str, Any]) -> bool:
+        return self._compare(instruction, operator.ge)
 
     def _op_select(self, instruction: MutableMapping[str, Any]) -> Any:
         mask = self._resolve(instruction.get("mask"))

--- a/tests/runtime/test_branchless_executor.py
+++ b/tests/runtime/test_branchless_executor.py
@@ -1,0 +1,37 @@
+import pytest
+
+from bambusa.runtime.executor import BranchlessExecutor
+
+
+@pytest.mark.parametrize(
+    "opcode,lhs,rhs,expected_mask",
+    [
+        ("cmp_eq", 4, 4, True),
+        ("cmp_eq", 4, 3, False),
+        ("cmp_ne", 4, 3, True),
+        ("cmp_ne", 5, 5, False),
+        ("cmp_lt", 2, 9, True),
+        ("cmp_lt", 9, 2, False),
+        ("cmp_le", 5, 5, True),
+        ("cmp_le", 7, 5, False),
+        ("cmp_gt", 8, 1, True),
+        ("cmp_gt", 1, 8, False),
+        ("cmp_ge", 6, 2, True),
+        ("cmp_ge", 2, 6, False),
+    ],
+)
+def test_comparison_opcodes_drive_select(opcode, lhs, rhs, expected_mask) -> None:
+    executor = BranchlessExecutor()
+    program = [
+        {"op": "const", "target": "lhs", "value": lhs},
+        {"op": "const", "target": "rhs", "value": rhs},
+        {"op": opcode, "target": "mask", "lhs": "lhs", "rhs": "rhs"},
+        {"op": "select", "target": "result", "mask": "mask", "true": "lhs", "false": "rhs"},
+    ]
+
+    registers = executor.run(program)
+
+    assert isinstance(registers["mask"], bool)
+    assert registers["mask"] is expected_mask
+    expected_result = lhs if expected_mask else rhs
+    assert registers["result"] == expected_result


### PR DESCRIPTION
## Summary
- document the branchless runtime opcode naming scheme so it aligns with the lowering pipeline
- implement comparison handlers in the BranchlessExecutor that resolve operands and return booleans
- add regression tests covering the new comparison opcodes working in concert with select

## Testing
- pytest tests/runtime

------
https://chatgpt.com/codex/tasks/task_e_68dd1c5ffc808328abb9ff0d8374f2fa