### PR TITLE
Ensure timeline logs materialised vectors for JSON output

### DIFF
--- a/src/bambusa/runtime/executor.py
+++ b/src/bambusa/runtime/executor.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Dict, Iterable, List, Mapping, MutableMapping, Optional, Sequence
-import copy
 import json
 
 from .persistent_heap import (
@@ -14,6 +13,26 @@ from .persistent_heap import (
     masked_load,
     masked_store,
 )
+
+
+def _materialise_value(value: Any) -> Any:
+    """Recursively materialise persistent vectors within ``value``."""
+
+    if isinstance(value, PersistentVector):
+        return value.materialise()
+    if isinstance(value, Mapping):
+        return {key: _materialise_value(item) for key, item in value.items()}
+    if isinstance(value, list):
+        return [_materialise_value(item) for item in value]
+    if isinstance(value, tuple):
+        return tuple(_materialise_value(item) for item in value)
+    return value
+
+
+def _materialise_state(state: Mapping[str, Any]) -> Dict[str, Any]:
+    """Return a copy of ``state`` with vectors materialised into tuples."""
+
+    return {key: _materialise_value(value) for key, value in state.items()}
 
 
 class BranchlessExecutor:
@@ -137,14 +156,8 @@ class BranchlessExecutor:
     def snapshot(self, names: Sequence[str]) -> Dict[str, Any]:
         """Return a snapshot of selected registers (materialising vectors)."""
 
-        result: Dict[str, Any] = {}
-        for name in names:
-            value = self.registers.get(name)
-            if isinstance(value, PersistentVector):
-                result[name] = value.materialise()
-            else:
-                result[name] = value
-        return result
+        result: Dict[str, Any] = {name: self.registers.get(name) for name in names}
+        return _materialise_state(result)
 
 
 @dataclass
@@ -173,8 +186,8 @@ class StructuredLogWriter:
             return
         entry = {
             "step": step,
-            "instruction": instruction,
-            "state": copy.deepcopy(state),
+            "instruction": _materialise_state(instruction),
+            "state": _materialise_state(state),
         }
         json.dump(entry, self._file, sort_keys=True)
         self._file.write("\n")
@@ -222,10 +235,12 @@ class Executor:
         with StructuredLogWriter(log_path) as writer:
             for index, step in enumerate(self._steps):
                 self._execute_step(step)
+                instruction = _materialise_state({"op": step.op, **step.args})
+                state_snapshot = _materialise_state(self.state)
                 snapshot = {
                     "step": index,
-                    "instruction": {"op": step.op, **step.args},
-                    "state": copy.deepcopy(self.state),
+                    "instruction": instruction,
+                    "state": state_snapshot,
                 }
                 writer.snapshot(
                     step=index,

--- a/tests/debug/test_timeline.py
+++ b/tests/debug/test_timeline.py
@@ -9,6 +9,7 @@ import pytest
 
 from bambusa.debug.timeline import Timeline
 from bambusa.runtime.executor import Executor
+from bambusa.runtime.persistent_heap import PersistentHeap
 
 
 @pytest.fixture()
@@ -21,6 +22,29 @@ def sample_log(tmp_path: Path) -> Path:
     ]
     executor = Executor(steps, initial_state={"x": 0})
     log_path = tmp_path / "run.log"
+    executor.run(log_path=log_path)
+    return log_path
+
+
+@pytest.fixture()
+def persistent_vector_log(tmp_path: Path) -> Path:
+    heap = PersistentHeap()
+    vector = heap.allocate([1, 2, 3])
+    nested = {
+        "vector": vector,
+        "items": [vector, {"inner": vector}],
+    }
+    initial_state = {
+        "vec": vector,
+        "nested": nested,
+        "emissions": {},
+    }
+    steps = [
+        {"op": "add", "target": "counter", "value": 1},
+        {"op": "mul", "target": "counter", "value": 2},
+    ]
+    executor = Executor(steps, initial_state=initial_state)
+    log_path = tmp_path / "persistent_vector.log"
     executor.run(log_path=log_path)
     return log_path
 
@@ -93,6 +117,24 @@ def test_cli_json_mode(sample_log: Path) -> None:
     assert payload[0]["state"]["x"] == 1
 
 
+def test_cli_json_mode_with_persistent_vector(persistent_vector_log: Path) -> None:
+    env = os.environ.copy()
+    src_path = str(Path.cwd() / "src")
+    existing = env.get("PYTHONPATH", "")
+    env["PYTHONPATH"] = os.pathsep.join([src_path, existing]) if existing else src_path
+    result = subprocess.run(
+        [sys.executable, "-m", "bambusa", "timeline", str(persistent_vector_log), "--json"],
+        check=True,
+        capture_output=True,
+        env=env,
+    )
+    payload = json.loads(result.stdout.decode("utf-8"))
+    assert len(payload) == 2
+    assert payload[0]["state"]["vec"] == [1, 2, 3]
+    assert payload[1]["state"]["nested"]["vector"] == [1, 2, 3]
+    assert payload[1]["state"]["nested"]["items"][1]["inner"] == [1, 2, 3]
+
+
 def test_timeline_from_stream(sample_log: Path) -> None:
     log_text = sample_log.read_text(encoding="utf-8")
     timeline = Timeline.from_stream(StringIO(log_text))
@@ -121,3 +163,23 @@ def test_cli_json_mode_stdin(sample_log: Path) -> None:
     payload = json.loads(result.stdout)
     assert len(payload) == 4
     assert payload[-1]["step"] == 3
+
+
+def test_cli_json_mode_stdin_with_persistent_vector(persistent_vector_log: Path) -> None:
+    env = os.environ.copy()
+    src_path = str(Path.cwd() / "src")
+    existing = env.get("PYTHONPATH", "")
+    env["PYTHONPATH"] = os.pathsep.join([src_path, existing]) if existing else src_path
+
+    log_text = persistent_vector_log.read_text(encoding="utf-8")
+    result = subprocess.run(
+        [sys.executable, "-m", "bambusa", "timeline", "-", "--json"],
+        input=log_text,
+        text=True,
+        check=True,
+        capture_output=True,
+        env=env,
+    )
+    payload = json.loads(result.stdout)
+    assert payload[0]["state"]["vec"] == [1, 2, 3]
+    assert payload[-1]["state"]["nested"]["items"][0] == [1, 2, 3]


### PR DESCRIPTION
## Summary
- add helpers to recursively materialise PersistentVector instances before logging
- apply the materialisation when producing executor snapshots and structured logs
- add CLI timeline tests that cover persistent vector states in JSON mode

## Testing
- pytest tests/debug

------
https://chatgpt.com/codex/tasks/task_e_68dd1c6262588328908305f682b86136