### PR TITLE
Optimize timeline fork sharing

### DIFF
--- a/src/bambusa/debug/timeline.py
+++ b/src/bambusa/debug/timeline.py
@@ -28,8 +28,31 @@ class TimelineEntry:
 class Timeline:
     """Navigates execution histories produced by :class:`Executor`."""
 
-    def __init__(self, entries: Iterable[TimelineEntry]):
-        self._entries: List[TimelineEntry] = list(entries)
+    def __init__(
+        self,
+        entries: Iterable[TimelineEntry],
+        *,
+        _shared: bool = False,
+    ) -> None:
+        """Create a timeline from an iterable of entries.
+
+        Parameters
+        ----------
+        entries:
+            Source entries to populate the timeline.  By default the iterable is
+            eagerly copied into an internal list so that external mutations do
+            not affect the timeline.  When ``_shared`` is ``True`` the provided
+            list is re-used directly which allows efficient cloning of existing
+            timelines.  The flag is private to discourage callers from
+            accidentally sharing mutable buffers.
+        """
+
+        if _shared:
+            if not isinstance(entries, list):
+                raise TypeError("Shared timelines require a concrete list")
+            self._entries = entries
+        else:
+            self._entries = list(entries)
         if not self._entries:
             raise ValueError("Timeline requires at least one entry")
         self._index: int = 0
@@ -103,7 +126,7 @@ class Timeline:
     # Forking and diffing
 
     def fork(self, *, at_step: Optional[int] = None) -> "Timeline":
-        clone = Timeline(self._entries)
+        clone = Timeline(self._entries, _shared=True)
         if at_step is None:
             clone._index = self._index
         else:

--- a/tests/debug/test_timeline.py
+++ b/tests/debug/test_timeline.py
@@ -7,7 +7,7 @@ from pathlib import Path
 
 import pytest
 
-from bambusa.debug.timeline import Timeline
+from bambusa.debug.timeline import Timeline, TimelineEntry
 from bambusa.runtime.executor import Executor
 
 
@@ -121,3 +121,36 @@ def test_cli_json_mode_stdin(sample_log: Path) -> None:
     payload = json.loads(result.stdout)
     assert len(payload) == 4
     assert payload[-1]["step"] == 3
+
+
+def test_timeline_initialisation_copies_entries() -> None:
+    entries = [
+        TimelineEntry(step=idx, instruction={}, state={"value": idx})
+        for idx in range(5)
+    ]
+
+    timeline = Timeline(entries)
+
+    # Mutating the caller's list must not affect the timeline's backing store.
+    entries.append(
+        TimelineEntry(step=99, instruction={"op": "noop"}, state={"value": 99})
+    )
+
+    assert timeline.size == 5
+
+
+def test_timeline_fork_reuses_entries_buffer() -> None:
+    large_entries = [
+        TimelineEntry(step=idx, instruction={"op": "noop"}, state={"value": idx})
+        for idx in range(50_000)
+    ]
+
+    timeline = Timeline(large_entries)
+    fork = timeline.fork()
+
+    assert fork._entries is timeline._entries
+    assert fork.size == timeline.size
+
+    # Seeking deep into the fork should succeed without recomputing the buffer.
+    fork.seek(49_999)
+    assert fork.current_state["value"] == 49_999


### PR DESCRIPTION
## Summary
- allow `Timeline` to reuse an existing entry list via a private constructor flag while keeping public constructors defensive
- update `Timeline.fork` to share the backing entry buffer instead of copying
- add regression tests covering copy-on-construction and large fork sharing behaviour

## Testing
- pytest tests/debug/test_timeline.py

------
https://chatgpt.com/codex/tasks/task_e_68dd1c65cbf883288f68c6c4f840ccdb