### PR TITLE
Allow diff command to compare against specific root step

### DIFF
--- a/src/bambusa/cli/main.py
+++ b/src/bambusa/cli/main.py
@@ -121,7 +121,7 @@ def run_timeline(args: argparse.Namespace) -> int:
                     print("usage: diff <step> [root_step]")
                     continue
                 step = int(rest[0])
-                other_step = root.current_step if len(rest) == 1 else int(rest[1])
+                other_step = step if len(rest) == 1 else int(rest[1])
                 diff = current.diff(root, step=step, other_step=other_step)
                 print(json.dumps(diff, indent=2, sort_keys=True))
             else:

--- a/src/bambusa/cli/main.py
+++ b/src/bambusa/cli/main.py
@@ -117,10 +117,12 @@ def run_timeline(args: argparse.Namespace) -> int:
                 current_label = label_stack.pop()
                 print(f"Returned to timeline at step {current.current_step}")
             elif command == "diff":
-                step = None
-                if rest:
-                    step = int(rest[0])
-                diff = current.diff(root, step=step, other_step=step)
+                if not rest:
+                    print("usage: diff <step> [root_step]")
+                    continue
+                step = int(rest[0])
+                other_step = root.current_step if len(rest) == 1 else int(rest[1])
+                diff = current.diff(root, step=step, other_step=other_step)
                 print(json.dumps(diff, indent=2, sort_keys=True))
             else:
                 print(f"Unknown command: {command}. Type 'help' for available commands.")
@@ -132,7 +134,7 @@ def run_timeline(args: argparse.Namespace) -> int:
 def _format_banner(path: str, timeline: Timeline) -> str:
     return (
         f"Loaded timeline from {path}\n"
-        "Commands: next, prev, goto <step>, state, instruction, steps, diff [step],\n"
+        "Commands: next, prev, goto <step>, state, instruction, steps, diff <step> [root_step],\n"
         "          fork [step], back, help, quit"
     )
 
@@ -157,7 +159,8 @@ def _print_help() -> None:
         "  steps           - show the valid step range\n"
         "  fork [step]     - fork a new timeline from the current (or specified) step\n"
         "  back            - return to the parent timeline\n"
-        "  diff [step]     - diff against the root timeline at the current (or specified) step\n"
+        "  diff <step> [root_step] - diff against the root timeline at the given step,\n"
+        "                     optionally comparing to a specific root step\n"
         "  help            - print this message\n"
         "  quit / exit     - leave the debugger"
     )

--- a/tests/debug/test_timeline.py
+++ b/tests/debug/test_timeline.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 import pytest
 
+from bambusa.cli import main as cli_main
 from bambusa.debug.timeline import Timeline, TimelineEntry
 from bambusa.runtime.executor import Executor
 from bambusa.runtime.persistent_heap import PersistentHeap
@@ -133,6 +134,30 @@ def test_cli_json_mode_with_persistent_vector(persistent_vector_log: Path) -> No
     assert payload[0]["state"]["vec"] == [1, 2, 3]
     assert payload[1]["state"]["nested"]["vector"] == [1, 2, 3]
     assert payload[1]["state"]["nested"]["items"][1]["inner"] == [1, 2, 3]
+
+
+def test_cli_diff_accepts_root_step_argument(
+    sample_log: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    commands = iter(["diff 2 1", "quit"])
+
+    def fake_input(prompt: str) -> str:
+        try:
+            return next(commands)
+        except StopIteration:
+            raise EOFError
+
+    monkeypatch.setattr("builtins.input", fake_input)
+
+    exit_code = cli_main.main(["timeline", str(sample_log)])
+    assert exit_code == 0
+
+    captured = capsys.readouterr()
+    start = captured.out.find("{")
+    end = captured.out.rfind("}")
+    assert start != -1 and end != -1 and end > start
+    diff_output = json.loads(captured.out[start : end + 1])
+    assert diff_output["removed"]["y"] == 3
 
 
 def test_timeline_from_stream(sample_log: Path) -> None:

--- a/tests/debug/test_timeline.py
+++ b/tests/debug/test_timeline.py
@@ -160,6 +160,32 @@ def test_cli_diff_accepts_root_step_argument(
     assert diff_output["removed"]["y"] == 3
 
 
+def test_cli_diff_defaults_to_matching_root_step(
+    sample_log: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    commands = iter(["diff 2", "quit"])
+
+    def fake_input(prompt: str) -> str:
+        try:
+            return next(commands)
+        except StopIteration:
+            raise EOFError
+
+    monkeypatch.setattr("builtins.input", fake_input)
+
+    exit_code = cli_main.main(["timeline", str(sample_log)])
+    assert exit_code == 0
+
+    captured = capsys.readouterr()
+    start = captured.out.find("{")
+    end = captured.out.rfind("}")
+    assert start != -1 and end != -1 and end > start
+    diff_output = json.loads(captured.out[start : end + 1])
+    assert diff_output["added"] == {}
+    assert diff_output["removed"] == {}
+    assert diff_output["changed"] == {}
+
+
 def test_timeline_from_stream(sample_log: Path) -> None:
     log_text = sample_log.read_text(encoding="utf-8")
     timeline = Timeline.from_stream(StringIO(log_text))


### PR DESCRIPTION
## Summary
- update the timeline CLI diff command to accept an explicit root step argument and refresh the help text
- add a regression test that exercises the CLI with both timeline and root steps

## Testing
- pytest tests/debug/test_timeline.py::test_cli_diff_accepts_root_step_argument

------
https://chatgpt.com/codex/tasks/task_e_69020d31e78c8328ab7ae49112f3acc6