### PR TITLE
Handle KeyboardInterrupt in timeline CLI

### DIFF
--- a/src/bambusa/cli/main.py
+++ b/src/bambusa/cli/main.py
@@ -71,6 +71,9 @@ def run_timeline(args: argparse.Namespace) -> int:
         except EOFError:
             print()
             break
+        except KeyboardInterrupt:
+            print()
+            break
         if not raw:
             continue
         command, *rest = raw.split()

--- a/tests/debug/test_timeline.py
+++ b/tests/debug/test_timeline.py
@@ -1,3 +1,4 @@
+import argparse
 import json
 import os
 import subprocess
@@ -7,6 +8,7 @@ from pathlib import Path
 
 import pytest
 
+from bambusa.cli.main import run_timeline
 from bambusa.debug.timeline import Timeline, TimelineEntry
 from bambusa.runtime.executor import Executor
 from bambusa.runtime.persistent_heap import PersistentHeap
@@ -215,4 +217,22 @@ def test_timeline_fork_reuses_entries_buffer() -> None:
     # Seeking deep into the fork should succeed without recomputing the buffer.
     fork.seek(49_999)
     assert fork.current_state["value"] == 49_999
+
+
+def test_run_timeline_handles_keyboard_interrupt(
+    sample_log: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    args = argparse.Namespace(log=str(sample_log), json=False)
+
+    def _raise_keyboard_interrupt(*_: object, **__: object) -> str:
+        raise KeyboardInterrupt
+
+    monkeypatch.setattr("builtins.input", _raise_keyboard_interrupt)
+
+    exit_code = run_timeline(args)
+
+    assert exit_code == 0
+
+    captured = capsys.readouterr()
+    assert captured.out.endswith("\n")
 


### PR DESCRIPTION
## Summary
- break out of the timeline CLI loop when a KeyboardInterrupt occurs and ensure a clean newline is printed
- add a regression test that patches input to raise KeyboardInterrupt and asserts the CLI exits cleanly

## Testing
- pytest tests/debug/test_timeline.py -k keyboard -q

------
https://chatgpt.com/codex/tasks/task_e_69020d32c9908328b49a754d243e1b5b