### PR TITLE
Handle mapping operands in branchless executor

### DIFF
--- a/src/bambusa/runtime/executor.py
+++ b/src/bambusa/runtime/executor.py
@@ -91,6 +91,8 @@ class BranchlessExecutor:
     def _resolve(self, operand: Any) -> Any:
         if isinstance(operand, str) and operand in self.registers:
             return self.registers[operand]
+        if isinstance(operand, Mapping):
+            return {key: self._resolve(value) for key, value in operand.items()}
         if isinstance(operand, list):
             return [self._resolve(item) for item in operand]
         if isinstance(operand, tuple):

--- a/tests/runtime/test_branchless_executor.py
+++ b/tests/runtime/test_branchless_executor.py
@@ -76,3 +76,20 @@ def test_op_select_raises_on_shape_mismatch() -> None:
 
     with pytest.raises(ValueError):
         _select(executor, [True, False], [1, 2, 3], [4, 5, 6])
+
+
+def test_move_resolves_mapping_operands() -> None:
+    executor = BranchlessExecutor()
+
+    mapping_operand = {"lhs": "left", "rhs": "right"}
+    program = [
+        {"op": "const", "target": "left", "value": 10},
+        {"op": "const", "target": "right", "value": 20},
+        {"op": "move", "target": "result", "value": mapping_operand},
+    ]
+
+    registers = executor.run(program)
+
+    assert registers["result"] == {"lhs": 10, "rhs": 20}
+    assert registers["result"] is not mapping_operand
+    assert mapping_operand == {"lhs": "left", "rhs": "right"}


### PR DESCRIPTION
## Summary
- extend BranchlessExecutor._resolve to recursively resolve mapping operands
- add a regression test covering dict operands passed through the move instruction

## Testing
- pytest tests/runtime/test_branchless_executor.py

------
https://chatgpt.com/codex/tasks/task_e_69020d33fda88328a95ad160cb96d810