### PR TITLE
Handle unreadable sources in parser CLI

### DIFF
--- a/src/bambusa/parser/cli.py
+++ b/src/bambusa/parser/cli.py
@@ -70,7 +70,10 @@ def _parse_source(path: Path) -> tuple[ParseTree, BambusaParser]:
     if not path.exists():
         raise FileNotFoundError(path)
 
-    input_stream = FileStream(str(path), encoding="utf-8")
+    try:
+        input_stream = FileStream(str(path), encoding="utf-8")
+    except OSError as exc:
+        raise OSError(str(path)) from exc
 
     lexer = BambusaLexer(input_stream)
     parser_error_listener = _CollectingErrorListener()
@@ -124,6 +127,9 @@ def handle_parse_command(args) -> int:
         tree, parser = _parse_source(args.path)
     except FileNotFoundError:
         print(f"bambusa: file not found: {args.path}", file=sys.stderr)
+        return 1
+    except OSError:
+        print(f"bambusa: cannot read {args.path}", file=sys.stderr)
         return 1
     except BambusaSyntaxError as exc:
         print(f"bambusa: {exc}", file=sys.stderr)

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+import stat
 import subprocess
 import sys
 from pathlib import Path
@@ -46,3 +47,25 @@ def test_parse_json_output_matches_golden() -> None:
     assert result.returncode == 0, result.stderr
     expected = (DATA_DIR / "global_tree.json").read_text().strip()
     assert result.stdout.strip() == expected
+
+
+_SKIP_UNREADABLE = os.name == "nt" or (hasattr(os, "geteuid") and os.geteuid() == 0)
+
+
+@pytest.mark.skipif(
+    _SKIP_UNREADABLE,
+    reason="Restricted-permission test not supported on this platform",
+)
+def test_cli_handles_unreadable_file(tmp_path: Path) -> None:
+    path = tmp_path / "unreadable.bam"
+    path.write_text("fn main() {}\n", encoding="utf-8")
+
+    original_mode = stat.S_IMODE(path.stat().st_mode)
+    path.chmod(0)
+    try:
+        result = _run_cli("parse", str(path))
+    finally:
+        path.chmod(original_mode)
+
+    assert result.returncode == 1
+    assert result.stderr.strip().splitlines()[-1] == f"bambusa: cannot read {path}"


### PR DESCRIPTION
## Summary
- print a clear error when the parser CLI cannot read the requested source file
- cover unreadable file scenarios with a CLI test that restricts file permissions

## Testing
- pytest tests/test_parser.py

------
https://chatgpt.com/codex/tasks/task_e_69020d3616a08328a8df2163335b4a5b