### PR TITLE
Make branchless executor use explicit register refs

### DIFF
--- a/src/bambusa/runtime/executor.py
+++ b/src/bambusa/runtime/executor.py
@@ -15,13 +15,11 @@ lowering pipeline:
 """
 from __future__ import annotations
 
-import copy
 import json
 import operator
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Dict, Iterable, List, Mapping, MutableMapping, Optional, Sequence
-import json
 
 from .persistent_heap import (
     PersistentHeap,
@@ -89,9 +87,9 @@ class BranchlessExecutor:
     # Instruction helpers
     # ------------------------------------------------------------------
     def _resolve(self, operand: Any) -> Any:
-        if isinstance(operand, str) and operand in self.registers:
-            return self.registers[operand]
         if isinstance(operand, Mapping):
+            if set(operand.keys()) == {"ref"}:
+                return self.registers[operand["ref"]]
             return {key: self._resolve(value) for key, value in operand.items()}
         if isinstance(operand, list):
             return [self._resolve(item) for item in operand]

--- a/tests/runtime/test_branchless_executor.py
+++ b/tests/runtime/test_branchless_executor.py
@@ -26,8 +26,14 @@ def test_comparison_opcodes_drive_select(opcode, lhs, rhs, expected_mask) -> Non
     program = [
         {"op": "const", "target": "lhs", "value": lhs},
         {"op": "const", "target": "rhs", "value": rhs},
-        {"op": opcode, "target": "mask", "lhs": "lhs", "rhs": "rhs"},
-        {"op": "select", "target": "result", "mask": "mask", "true": "lhs", "false": "rhs"},
+        {"op": opcode, "target": "mask", "lhs": {"ref": "lhs"}, "rhs": {"ref": "rhs"}},
+        {
+            "op": "select",
+            "target": "result",
+            "mask": {"ref": "mask"},
+            "true": {"ref": "lhs"},
+            "false": {"ref": "rhs"},
+        },
     ]
 
     registers = executor.run(program)
@@ -43,7 +49,9 @@ def _select(executor: BranchlessExecutor, mask, true_value, false_value):
         "true": true_value,
         "false": false_value,
     })
-    return executor._op_select({"mask": "mask", "true": "true", "false": "false"})
+    return executor._op_select(
+        {"mask": {"ref": "mask"}, "true": {"ref": "true"}, "false": {"ref": "false"}}
+    )
 
 
 def test_op_select_with_scalar_mask() -> None:
@@ -78,18 +86,53 @@ def test_op_select_raises_on_shape_mismatch() -> None:
         _select(executor, [True, False], [1, 2, 3], [4, 5, 6])
 
 
-def test_move_resolves_mapping_operands() -> None:
+def test_move_keeps_plain_strings_as_literals() -> None:
     executor = BranchlessExecutor()
+    program = [{"op": "move", "target": "result", "value": "left"}]
 
-    mapping_operand = {"lhs": "left", "rhs": "right"}
+    registers = executor.run(program)
+
+    assert registers["result"] == "left"
+
+
+def test_move_resolves_explicit_refs() -> None:
+    executor = BranchlessExecutor()
     program = [
         {"op": "const", "target": "left", "value": 10},
-        {"op": "const", "target": "right", "value": 20},
-        {"op": "move", "target": "result", "value": mapping_operand},
+        {"op": "move", "target": "result", "value": {"ref": "left"}},
     ]
 
     registers = executor.run(program)
 
-    assert registers["result"] == {"lhs": 10, "rhs": 20}
-    assert registers["result"] is not mapping_operand
-    assert mapping_operand == {"lhs": "left", "rhs": "right"}
+    assert registers["result"] == 10
+
+
+def test_move_resolves_nested_structures_recursively() -> None:
+    executor = BranchlessExecutor()
+
+    nested_operand = {
+        "literal": "left",
+        "dict_ref": {"ref": "left"},
+        "list_values": ["right", {"ref": "right"}],
+        "tuple_values": ("left", {"ref": "left"}),
+    }
+    program = [
+        {"op": "const", "target": "left", "value": 10},
+        {"op": "const", "target": "right", "value": 20},
+        {"op": "move", "target": "result", "value": nested_operand},
+    ]
+
+    registers = executor.run(program)
+
+    assert registers["result"] == {
+        "literal": "left",
+        "dict_ref": 10,
+        "list_values": ["right", 20],
+        "tuple_values": ("left", 10),
+    }
+    assert nested_operand == {
+        "literal": "left",
+        "dict_ref": {"ref": "left"},
+        "list_values": ["right", {"ref": "right"}],
+        "tuple_values": ("left", {"ref": "left"}),
+    }


### PR DESCRIPTION
### Motivation

- Avoid accidental interpretation of plain Python strings as register names by making register lookups explicit. 
- Provide a clear, explicit shape for referencing registers (`{"ref": "name"}`) so operand resolution is unambiguous. 
- Preserve recursive resolution behavior for nested dict/list/tuple structures while ensuring literals remain unchanged.

### Description

- Changed `BranchlessExecutor._resolve` to treat plain strings as literals and to resolve only mappings with the exact shape `{"ref": "<name>"}` into register values. 
- Kept all instruction handlers (`_op_move`, arithmetic ops, comparison/select/masked ops) using `_resolve`, enabling them to accept the explicit-ref format without further changes. 
- Updated existing tests to pass explicit refs for comparison/select operands and replaced string-lookups with `{"ref": ...}` where appropriate. 
- Added tests that assert plain strings remain literals, explicit refs resolve to register values, and nested dict/list/tuple operands are resolved recursively while leaving the original input structures intact.

### Testing

- Ran `pytest -q tests/runtime/test_branchless_executor.py` and all tests passed (`19 passed`).
- The modified test suite verifies comparison/select behavior, literal preservation, explicit ref resolution, and recursive resolution of nested structures.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d179512f2483289eaebba7db74a3e2)