### PR TITLE
Validate timeline step ordering and uniqueness

### DIFF
--- a/src/bambusa/debug/timeline.py
+++ b/src/bambusa/debug/timeline.py
@@ -55,16 +55,41 @@ class Timeline:
             self._step_positions = (
                 _step_positions
                 if _step_positions is not None
-                else {entry.step: idx for idx, entry in enumerate(self._entries)}
+                else self._build_step_positions(self._entries)
             )
         else:
             self._entries = list(entries)
-            self._step_positions = {
-                entry.step: idx for idx, entry in enumerate(self._entries)
-            }
+            self._step_positions = self._build_step_positions(self._entries)
         if not self._entries:
             raise ValueError("Timeline requires at least one entry")
         self._index: int = 0
+
+    @staticmethod
+    def _build_step_positions(entries: List[TimelineEntry]) -> Dict[int, int]:
+        step_positions: Dict[int, int] = {}
+        previous_step: Optional[int] = None
+
+        for idx, entry in enumerate(entries):
+            step = entry.step
+            if step in step_positions:
+                first_index = step_positions[step]
+                raise ValueError(
+                    "Timeline contains duplicate step "
+                    f"{step} at indices {first_index} and {idx}; "
+                    "ensure each snapshot has a unique step."
+                )
+
+            if previous_step is not None and step <= previous_step:
+                raise ValueError(
+                    "Timeline steps must be strictly increasing; "
+                    f"found step {step} at index {idx} after {previous_step}. "
+                    "Sort the log by step and remove duplicates before loading."
+                )
+
+            step_positions[step] = idx
+            previous_step = step
+
+        return step_positions
 
     # ------------------------------------------------------------------
     # Construction helpers

--- a/tests/debug/test_timeline.py
+++ b/tests/debug/test_timeline.py
@@ -215,6 +215,53 @@ def test_timeline_from_stream(sample_log: Path) -> None:
     assert timeline.current_state["emissions"]["stdout"] == ["done"]
 
 
+def test_timeline_from_stream_rejects_duplicate_steps() -> None:
+    stream = StringIO(
+        "\n".join(
+            [
+                json.dumps({"step": 0, "instruction": {"op": "assign"}, "state": {"x": 1}}),
+                json.dumps({"step": 0, "instruction": {"op": "add"}, "state": {"x": 2}}),
+            ]
+        )
+    )
+
+    with pytest.raises(ValueError, match=r"duplicate step 0"):
+        Timeline.from_stream(stream)
+
+
+def test_timeline_from_stream_rejects_out_of_order_steps() -> None:
+    stream = StringIO(
+        "\n".join(
+            [
+                json.dumps({"step": 1, "instruction": {"op": "assign"}, "state": {"x": 1}}),
+                json.dumps({"step": 0, "instruction": {"op": "assign"}, "state": {"x": 0}}),
+            ]
+        )
+    )
+
+    with pytest.raises(ValueError, match=r"strictly increasing"):
+        Timeline.from_stream(stream)
+
+
+def test_timeline_from_stream_accepts_strictly_increasing_steps() -> None:
+    stream = StringIO(
+        "\n".join(
+            [
+                json.dumps({"step": 0, "instruction": {"op": "assign"}, "state": {"x": 1}}),
+                json.dumps({"step": 1, "instruction": {"op": "add"}, "state": {"x": 3}}),
+                json.dumps({"step": 2, "instruction": {"op": "emit"}, "state": {"x": 3}}),
+            ]
+        )
+    )
+
+    timeline = Timeline.from_stream(stream)
+
+    assert timeline.size == 3
+    assert timeline.current_step == 0
+    timeline.seek(2)
+    assert timeline.current_state["x"] == 3
+
+
 def test_cli_json_mode_stdin(sample_log: Path) -> None:
     env = os.environ.copy()
     src_path = str(Path.cwd() / "src")
@@ -303,4 +350,3 @@ def test_run_timeline_handles_keyboard_interrupt(
 
     captured = capsys.readouterr()
     assert captured.out.endswith("\n")
-


### PR DESCRIPTION
### Motivation

- Ensure timelines loaded from logs are well-formed by detecting duplicate `step` identifiers early. 
- Prevent surprising behavior when steps are duplicated or out-of-order by enforcing a clear policy at construction time. 
- Provide actionable error messages so callers can fix log input (sort/remove duplicates) rather than debugging downstream failures.

### Description

- Add a centralized `_build_step_positions` helper used by `Timeline.__init__` to construct the step index map with validation. 
- Reject duplicate step IDs with a `ValueError` that includes both indices where the duplicate occurs. 
- Enforce a strictly increasing step ordering policy and raise a `ValueError` for non-increasing or out-of-order steps with an actionable message. 
- Add tests in `tests/debug/test_timeline.py` to cover duplicate steps, out-of-order steps, and a happy-path strictly increasing log.

### Testing

- Ran the timeline test suite with `pytest -q tests/debug/test_timeline.py`. 
- All tests succeeded: `17 passed`. 
- The new tests exercise `Timeline.from_stream` rejection of duplicate and out-of-order steps and the acceptance of strictly increasing sequences.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d17955516c8328a31afdb62a695043)