### PR TITLE
Detect unreachable statements after guaranteed returns

### DIFF
--- a/src/bambusa/semantic/type_checker.py
+++ b/src/bambusa/semantic/type_checker.py
@@ -126,13 +126,17 @@ class TypeChecker:
     def _check_block(self, block: ast.Block, *, new_scope: bool = True) -> bool:
         if new_scope:
             self._push_scope()
-        block_returns = False
-        for statement in block.statements:
-            statement_returns = self._check_statement(statement)
-            block_returns = block_returns or statement_returns
-        if new_scope:
-            self._pop_scope()
-        return block_returns
+        try:
+            block_returns = False
+            for statement in block.statements:
+                if block_returns:
+                    self._error(statement.location, "unreachable statement")
+                statement_returns = self._check_statement(statement)
+                block_returns = statement_returns
+            return block_returns
+        finally:
+            if new_scope:
+                self._pop_scope()
 
     def _check_statement(self, statement: ast.Statement) -> bool:
         if isinstance(statement, ast.Block):

--- a/tests/semantic/test_type_checker.py
+++ b/tests/semantic/test_type_checker.py
@@ -91,3 +91,37 @@ def test_function_returns_across_multiple_branches() -> None:
     }
     """
     _check(source)
+
+
+def test_unreachable_statement_after_return_raises() -> None:
+    source = """
+    fn bad() -> int {
+        return 1;
+        2;
+    }
+    """
+    with pytest.raises(SemanticError) as excinfo:
+        _check(source)
+    assert "unreachable statement" in str(excinfo.value)
+
+
+def test_unreachable_after_if_else_with_returning_branches_raises() -> None:
+    source = """
+    fn bad(bool cond) -> int {
+        if cond then { return 1; } else { return 2; }
+        3;
+    }
+    """
+    with pytest.raises(SemanticError) as excinfo:
+        _check(source)
+    assert "unreachable statement" in str(excinfo.value)
+
+
+def test_mixed_control_flow_block_with_fallthrough_still_type_checks() -> None:
+    source = """
+    fn ok(bool cond) -> int {
+        if cond then { return 1; }
+        return 2;
+    }
+    """
+    _check(source)


### PR DESCRIPTION
### Motivation
- Ensure the type checker flags unreachable statements that appear after a prior statement that guarantees a return in the same block.
- Correctly handle nested conditionals so that an `if` only counts as returning when both branches return.
- Preserve proper scope cleanup when reporting errors during block traversal.

### Description
- Updated `TypeChecker._check_block` to track sequential control flow and raise `SemanticError(statement.location, "unreachable statement")` for any statement following a guaranteed-return statement in the same block.
- Adjusted `_check_block` to use a `try/finally` so that pushed scopes are always popped even when an error is raised mid-block.
- Left `IfStmt` semantics unchanged so `if` reports as returning only when both `then` and `else` blocks return, which enables correct behavior for nested conditionals.
- Added tests in `tests/semantic/test_type_checker.py` covering direct unreachable statements after `return`, unreachable code following an `if/else` where both branches return, and a valid mixed-control-flow case that should still pass.

### Testing
- Ran `pytest -q tests/semantic/test_type_checker.py` and observed all tests pass.
- Test run summary: `10 passed`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d1795b5e6883289a2193ac3553c21c)